### PR TITLE
Uprava logovani

### DIFF
--- a/src/Keboola/ElasticsearchWriter/Writer.php
+++ b/src/Keboola/ElasticsearchWriter/Writer.php
@@ -114,7 +114,6 @@ class Writer
 				if ($responses['errors'] !== false) {
 					if (!empty($responses['items'])) {
 						foreach ($responses['items'] as $itemResult) {
-							// error message
 							if (!empty($itemResult['index']['error'])) {
 								if (is_array($itemResult['index']['error'])) {
 									$this->logger->error(sprintf(
@@ -124,12 +123,6 @@ class Writer
 								} else {
 									$this->logger->error(sprintf("ES error: %s", $itemResult['index']['error'] ));
 								}
-								return false;
-							}
-
-							// error status
-							if (!empty($itemResult['index']['status']) && $itemResult['index']['status'] >= 400) {
-								$this->logger->error(sprintf("ES error: %s", json_encode($itemResult['index'])));
 								return false;
 							}
 						}
@@ -166,7 +159,6 @@ class Writer
 			if ($responses['errors'] !== false) {
 				if (!empty($responses['items'])) {
 					foreach ($responses['items'] as $itemResult) {
-						// error message
 						if (!empty($itemResult['index']['error'])) {
 							if (is_array($itemResult['index']['error'])) {
 								$this->logger->error(sprintf(
@@ -176,12 +168,6 @@ class Writer
 							} else {
 								$this->logger->error(sprintf("ES error: %s", $itemResult['index']['error'] ));
 							}
-							return false;
-						}
-
-						// error status
-						if (!empty($itemResult['index']['status']) && $itemResult['index']['status'] >= 400) {
-							$this->logger->error(sprintf("ES error: %s", json_encode($itemResult['index'])));
 							return false;
 						}
 					}

--- a/src/Keboola/ElasticsearchWriter/Writer.php
+++ b/src/Keboola/ElasticsearchWriter/Writer.php
@@ -114,23 +114,14 @@ class Writer
 				if ($responses['errors'] !== false) {
 					if (!empty($responses['items'])) {
 						foreach ($responses['items'] as $itemResult) {
-							if (!empty($itemResult['index']['error'])) {
-								if (is_array($itemResult['index']['error'])) {
-									$this->logger->error(sprintf(
-										"ES error: %s",
-										$this->getErrorMessageFromErrorField($itemResult['index']['error'])
-									));
-								} else {
-									$this->logger->error(sprintf("ES error: %s", $itemResult['index']['error'] ));
-								}
-								return false;
+							$operation = key($itemResult);
+
+							if ($itemResult[$operation]['status'] >= 400) {
+								$this->logItemError($itemResult[$operation]);
 							}
 						}
-
-						unset($responses['items']);
 					}
 
-					$this->logger->error(sprintf("ES error: %s", json_encode($responses)));
 					return false;
 				}
 				
@@ -159,23 +150,14 @@ class Writer
 			if ($responses['errors'] !== false) {
 				if (!empty($responses['items'])) {
 					foreach ($responses['items'] as $itemResult) {
-						if (!empty($itemResult['index']['error'])) {
-							if (is_array($itemResult['index']['error'])) {
-								$this->logger->error(sprintf(
-									"ES error: %s",
-									$this->getErrorMessageFromErrorField($itemResult['index']['error'])
-								));
-							} else {
-								$this->logger->error(sprintf("ES error: %s", $itemResult['index']['error'] ));
-							}
-							return false;
+						$operation = key($itemResult);
+
+						if ($itemResult[$operation]['status'] >= 400) {
+							$this->logItemError($itemResult[$operation]);
 						}
 					}
-
-					unset($responses['items']);
 				}
 
-				$this->logger->error(sprintf("ES error: %s", json_encode($responses)));
 				return false;
 			}
 
@@ -236,5 +218,24 @@ class Writer
 		}
 
 		return $return;
+	}
+
+	private function logItemError(array $item)
+	{
+		if (!empty($item['error'])) {
+			if (is_array($item['error'])) {
+				$this->logger->error(sprintf(
+					"ES error(document ID '%s'): %s",
+					$item['_id'],
+					$this->getErrorMessageFromErrorField($item['error'])
+				));
+			} else {
+				$this->logger->error(sprintf(
+					"ES error(document ID '%s'): %s",
+					$item['_id'],
+					$item['error']
+				));
+			}
+		}
 	}
 }

--- a/tests/Keboola/ElasticsearchWriter/LoadTest.php
+++ b/tests/Keboola/ElasticsearchWriter/LoadTest.php
@@ -53,12 +53,12 @@ class LoadTest extends AbstractTest
 		$writer->enableLogger((new Logger($this->index))->setHandlers([$testHandler]));
 
 		$options = new LoadOptions();
-		$options->setIndex($this->index)
-			->setType('language-invalid')
+		$options->setIndex(strtoupper($this->index))
+			->setType('language')
 			->setBulkSize(LoadOptions::DEFAULT_BULK_SIZE);
 
 		$csv1 = new CsvFile(__DIR__ .'/../../data/csv/' . $options->getType() .'.csv');
-		$result = $writer->loadFile($csv1, $options, 'id');
+		$result = $writer->loadFile($csv1, $options);
 
 		$this->assertFalse($result);
 
@@ -66,10 +66,6 @@ class LoadTest extends AbstractTest
 		foreach ($testHandler->getRecords() as $record) {
 			if ($record['level'] === 400){
 				$errorsCount++;
-
-				$this->assertContains('ES error', $record['message']);
-				$this->assertRegExp("/document ID \'[\d]+\'/", $record['message']);
-				$this->assertContains('iso.dot.name', $record['message']);
 			}
 		}
 

--- a/tests/data/csv/language-invalid.csv
+++ b/tests/data/csv/language-invalid.csv
@@ -1,5 +1,0 @@
-"id","name","iso.dot.name","something"
-"26","czech","cs",""
-"1","english","en","test"
-"11","german","de",""
-"24","french","fr",""

--- a/tests/data/csv/language-invalid.csv
+++ b/tests/data/csv/language-invalid.csv
@@ -1,0 +1,5 @@
+"id","name","iso.dot.name","something"
+"26","czech","cs",""
+"1","english","en","test"
+"11","german","de",""
+"24","french","fr",""


### PR DESCRIPTION
Upravil jsem logovani tak, aby se logovaly chyby u vsech typu akci, nikoliv pouze `index`.

Writer sice posila pouze `index` akce, ale zjistil jsem ze kdyz to vytvari novy dokument, tak to misto akce `index` vrati `create`. To bude ten problem, proc jim to zadnou chybu nezaloguje.

Doted se taky logovala pouze prvni chyba. Nove se zaloguji vsechny chyby z jedne davky.

Doplneno i o test.