### PR TITLE
Columns mapping

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,11 @@ Writer expects that mapping of types and indexes in your Elasticsearch exists. I
     - `type` - type of the data, determines the type in ES,
     - `id` *(optional)* - determines in which column of table is the document's ID/primary key
     - `export` - whether this table shall be exported to ES
+- The optional`items` section defines columns mapping
+    - `name` string (required) - name of the column in CSV file
+    - `dbName` string (required) - name in the database
+    - `type` string (required) - type in the database. Special type "ignore" serves to ignore column present in CSV file.
+    - `nullable` bool (required) - is nullable?
 
 ### Example
 
@@ -76,6 +81,36 @@ Writer expects that mapping of types and indexes in your Elasticsearch exists. I
             "type": "products",
             "id": "id",
             "export": true
+        }
+    ]
+}
+```
+
+### Example with columns mapping
+```json
+{
+    "elastic": "...",
+    "tables": [
+        {
+            "file": "products.csv",
+            "index": "production",
+            "type": "products",
+            "id": "id",
+            "export": true,
+            "items": [
+                {
+                    "name": "order",
+                    "dbName": "order",
+                    "type": "integer",
+                    "nullable": false
+                },
+                {
+                    "name": "vat",
+                    "dbName": "vat-usa",
+                    "type": "double",
+                    "nullable": true
+                }
+            ]
         }
     ]
 }

--- a/src/Keboola/ElasticsearchWriter/Application.php
+++ b/src/Keboola/ElasticsearchWriter/Application.php
@@ -8,6 +8,7 @@ namespace Keboola\ElasticsearchWriter;
 use Elasticsearch;
 use Keboola\Csv\CsvFile;
 use Keboola\ElasticsearchWriter\Exception\UserException;
+use Keboola\ElasticsearchWriter\Mapping\ColumnsMapper;
 use Keboola\SSHTunnel\SSH;
 use Psr\Log\LoggerInterface;
 use Psr\Log\NullLogger;
@@ -133,8 +134,10 @@ class Application
 
 			// load options
 			$options = new Options\LoadOptions();
-			$options->setIndex($table['index'])
-				->setType($table['type']);
+			$options
+				->setIndex($table['index'])
+				->setType($table['type'])
+				->setColumns($table['items'] ?? []);
 
 			if (!empty($parameters['elastic']['bulkSize'])) {
 				$options->setBulkSize($parameters['elastic']['bulkSize']);

--- a/src/Keboola/ElasticsearchWriter/Mapping/ColumnsMapper.php
+++ b/src/Keboola/ElasticsearchWriter/Mapping/ColumnsMapper.php
@@ -3,9 +3,18 @@
 namespace Keboola\ElasticsearchWriter\Mapping;
 
 use Generator;
+use Keboola\ElasticsearchWriter\Exception\UserException;
 
 class ColumnsMapper
 {
+	const INTEGER_TYPES = ['long', 'integer', 'short', 'byte'];
+
+	const FLOAT_TYPES = ['double', 'float', 'half_float', 'scaled_float'];
+
+	const BOOLEAN_TYPES = ['boolean'];
+
+	const IGNORED_COLUMN_TYPE = 'ignore';
+
 	/** @var ColumnMapping[] */
 	private $columnsByCsvName = [];
 
@@ -17,14 +26,23 @@ class ColumnsMapper
 		}
 	}
 
+	public function getAllColumns()
+	{
+		return $this->columnsByCsvName;
+	}
+
 	public function mapCsvRow(array &$csvHeader, array &$values): Generator
 	{
 		foreach ($csvHeader as $index => $csvName) {
+			if (!isset($values[$index])) {
+				throw new UserException('Invalid CSV file.');
+			}
+
 			$column = $this->columnsByCsvName[$csvName] ?? null;
 			if (!$column) {
 				// Column is not present in mapping, it is used without change
 				yield $csvName => $values[$index];
-			} elseif ($column->getType() !== 'IGNORE') {
+			} elseif ($column->getType() !== self::IGNORED_COLUMN_TYPE) {
 				yield $column->getDbName() => $this->mapValue($column, (string) $values[$index]);
 			}
 		}
@@ -32,7 +50,34 @@ class ColumnsMapper
 
 	private function mapValue(ColumnMapping $column, string $value)
 	{
-		// TODO
+		if ($value === '' && $column->isNullable()) {
+			return null;
+		}
+
+		$type = $column->getType();
+		if (in_array($type, self::INTEGER_TYPES, true)) {
+			$intVal = (int) $value;
+			// PHP int is 32 bit, so for longer integers return string
+			return (string) $intVal === $value ? $intVal : $value;
+		}
+
+		if (in_array($type, self::FLOAT_TYPES, true)) {
+			return (float) $value;
+		}
+
+		if (in_array($type, self::BOOLEAN_TYPES, true)) {
+			$value = strtolower($value);
+			$firstLetter = substr($value, 0, 1) ;
+			if ($firstLetter === 't') {
+				// "t", or "true"
+				return true;
+			} else if ($firstLetter === 'f') {
+				// "f", or "false"
+				return false;
+			}
+			return (bool) $value;
+		}
+
 		return $value;
 	}
 }

--- a/src/Keboola/ElasticsearchWriter/Options/LoadOptions.php
+++ b/src/Keboola/ElasticsearchWriter/Options/LoadOptions.php
@@ -5,77 +5,73 @@
  */
 namespace Keboola\ElasticsearchWriter\Options;
 
+use Keboola\ElasticsearchWriter\Mapping\ColumnsMapper;
+
 class LoadOptions
 {
 	const DEFAULT_BULK_SIZE = 10000;
 
-	/**
-	 * @var string
-	 */
+	/** @var string */
 	private $index;
 
-	/**
-	 * @var string
-	 */
+	/** @var string */
 	private $type;
 
-	/**
-	 * @var int
-	 */
+	/** @var int */
 	private $bulkSize = self::DEFAULT_BULK_SIZE;
 
-	/**
-	 * @param $value
-	 * @return $this
-	 */
-	public function setIndex($value)
+	/** @var array */
+	private $columns = [];
+
+
+	public function setIndex($value): self
 	{
 		$this->index = (string) $value;
 		return $this;
 	}
 
-	/**
-	 * @return string
-	 */
-	public function getIndex()
+	public function getIndex(): string
 	{
 		return $this->index;
 	}
 
-	/**
-	 * @param $value
-	 * @return $this
-	 */
-	public function setType($value)
+	public function setType($value): self
 	{
 		$this->type = (string) $value;
 		return $this;
 	}
 
-	/**
-	 * @return string
-	 */
-	public function getType()
+	public function getType(): string
 	{
 		return $this->type;
 	}
 
-	/**
-	 * @param $value
-	 * @return $this
-	 */
-	public function setBulkSize($value)
+	public function setBulkSize($value): self
 	{
 		$this->bulkSize = (int) $value;
 		return $this;
 	}
 
-	/**
-	 * @return int
-	 */
-	public function getBulkSize()
+	public function getBulkSize(): int
 	{
 		return $this->bulkSize;
 
+	}
+
+	public function setColumns(array $columns): self
+	{
+		$this->columns = $columns;
+		return $this;
+	}
+
+
+	public function getColumns(): array
+	{
+		return $this->columns;
+	}
+
+	public function getColumnsMapper(): ColumnsMapper
+	{
+		return new ColumnsMapper($this->getColumns());
 	}
 }

--- a/src/Keboola/ElasticsearchWriter/Validator/ConfigValidator.php
+++ b/src/Keboola/ElasticsearchWriter/Validator/ConfigValidator.php
@@ -80,6 +80,43 @@ class ConfigValidator
 	 * @return bool
 	 * @throws InvalidConfigurationException
 	 */
+	private static function columnsConfigValidation(array $tables)
+	{
+		foreach ($tables as $tableIndex => $tableConfig) {
+			foreach ($tableConfig['items'] ?? [] as $columnIndex => $columnConfig) {
+				$logPrefix = sprintf('Table config %d, column %d: ', $tableIndex + 1, $columnIndex + 1);
+
+				if (empty($columnConfig['name'])) {
+					throw new InvalidConfigurationException($logPrefix . 'Missing "name" key.');
+				}
+
+				if (empty($columnConfig['dbName'])) {
+					throw new InvalidConfigurationException($logPrefix . 'Missing "dbName" key.');
+				}
+
+				if (empty($columnConfig['type'])) {
+					throw new InvalidConfigurationException($logPrefix . 'Missing "type" key.');
+				}
+
+				if (!isset($columnConfig['nullable'])) {
+					throw new InvalidConfigurationException($logPrefix . 'Missing "nullable" key.');
+				}
+
+				if (!is_bool($columnConfig['nullable'])) {
+					throw new InvalidConfigurationException($logPrefix . '"nullable" key must be boolean.');
+				}
+			}
+		}
+
+
+		return true;
+	}
+
+	/**
+	 * @param array $config
+	 * @return bool
+	 * @throws InvalidConfigurationException
+	 */
 	public static function validate(array $config)
 	{
 		if (!isset($config['parameters']) || !is_array($config['parameters'])) {
@@ -105,6 +142,8 @@ class ConfigValidator
 		if (isset($config['elastic']['ssh'])) {
 			self::sshConfigValidation($config['elastic']['ssh']);
 		}
+
+		self::columnsConfigValidation($config['tables']);
 
 		return true;
 	}

--- a/tests/Keboola/ElasticsearchWriter/AbstractTest.php
+++ b/tests/Keboola/ElasticsearchWriter/AbstractTest.php
@@ -11,13 +11,50 @@ use Symfony\Component\Process\Process;
 
 abstract class AbstractTest extends \PHPUnit_Framework_TestCase
 {
+	/** @var Writer */
+	protected $writer;
+
+	protected $index = 'keboola_es_writer_test';
+
+	protected function setUp()
+	{
+		$this->writer = new Writer(sprintf('%s:%s', getenv('EX_ES_HOST'), getenv('EX_ES_HOST_PORT')));
+		$this->cleanUp();
+	}
+
 	protected function tearDown()
 	{
 		parent::tearDown();
+		$this->cleanUp();
 
 		# Close SSH tunnel if created
 		$process = new Process(['sh', '-c', 'pgrep ssh | xargs -r kill']);
 		$process->mustRun();
+	}
+
+	/**
+	 * Cleanup test workspace
+	 *
+	 * @throws Elasticsearch\Common\Exceptions\Missing404Exception
+	 * @throws \Exception
+	 */
+	protected function cleanUp()
+	{
+		// Remove all indexes
+		foreach ($this->writer->getClient()->cat()->indices() as $data) {
+			$response = $this->writer->getClient()->indices()->delete([
+				'index' => $data['index']
+			]);
+
+			$this->assertArrayHasKey('acknowledged', $response);
+			$this->assertTrue($response['acknowledged']);
+		}
+
+
+		$configPath = './tests/data/run/config.yml';
+		if (file_exists($configPath)) {
+			unlink($configPath);
+		}
 	}
 
 	/**

--- a/tests/Keboola/ElasticsearchWriter/ConnectionTest.php
+++ b/tests/Keboola/ElasticsearchWriter/ConnectionTest.php
@@ -16,6 +16,7 @@ class ConnectionTest extends AbstractTest
 
 	protected function setUp()
 	{
+		parent::setUp();
 		$builder = Elasticsearch\ClientBuilder::create();
 		$builder->setHosts(array(sprintf('%s:%s', getenv('EX_ES_HOST'), getenv('EX_ES_HOST_PORT'))));
 		$this->client = $builder->build();

--- a/tests/Keboola/ElasticsearchWriter/LoadTest.php
+++ b/tests/Keboola/ElasticsearchWriter/LoadTest.php
@@ -14,38 +14,6 @@ use Monolog\Logger;
 
 class LoadTest extends AbstractTest
 {
-	/**
-	 * @var Writer
-	 */
-	protected $writer;
-
-	protected $index = 'keboola_es_writer_test';
-
-	protected function setUp()
-	{
-		$this->writer = new Writer(sprintf('%s:%s', getenv('EX_ES_HOST'), getenv('EX_ES_HOST_PORT')));
-
-		$this->cleanUp();
-	}
-
-	/**
-	 * Cleanup test workspace
-	 *
-	 * @throws Elasticsearch\Common\Exceptions\Missing404Exception
-	 * @throws \Exception
-	 */
-	protected function cleanUp()
-	{
-		$params = ['index' => $this->index];
-
-		if ($this->writer->getClient()->indices()->exists($params)) {
-			$response = $this->writer->getClient()->indices()->delete($params);
-
-			$this->assertArrayHasKey('acknowledged', $response);
-			$this->assertTrue($response['acknowledged']);
-		}
-	}
-
 	public function testLogBulkErrors()
 	{
 		$writer = $this->writer;

--- a/tests/Keboola/ElasticsearchWriter/RunTest.php
+++ b/tests/Keboola/ElasticsearchWriter/RunTest.php
@@ -5,50 +5,12 @@
  */
 namespace Keboola\ElasticsearchWriter;
 
-use Elasticsearch;
 use Keboola\Csv\CsvFile;
 use Keboola\ElasticsearchWriter\Exception\UserException;
 use Symfony\Component\Yaml\Yaml;
 
 class RunTest extends AbstractTest
 {
-	/**
-	 * @var Writer
-	 */
-	protected $writer;
-
-	protected $index = 'keboola_es_writer_run_test';
-
-	protected function setUp()
-	{
-		$this->writer = new Writer(sprintf('%s:%s', getenv('EX_ES_HOST'), getenv('EX_ES_HOST_PORT')));
-
-		$this->cleanUp();
-	}
-
-	/**
-	 * Cleanup test workspace
-	 *
-	 * @throws Elasticsearch\Common\Exceptions\Missing404Exception
-	 * @throws \Exception
-	 */
-	protected function cleanUp()
-	{
-		$params = ['index' => $this->index];
-
-		if ($this->writer->getClient()->indices()->exists($params)) {
-			$response = $this->writer->getClient()->indices()->delete($params);
-
-			$this->assertArrayHasKey('acknowledged', $response);
-			$this->assertTrue($response['acknowledged']);
-		}
-
-		$configPath = './tests/data/run/config.yml';
-		if (file_exists($configPath)) {
-			unlink($configPath);
-		}
-	}
-
 	public function testUserError()
 	{
 		$lastOutput = exec('php ./src/run.php --data=./tests/data/run', $output, $returnCode);

--- a/tests/Keboola/ElasticsearchWriter/SSHRunTest.php
+++ b/tests/Keboola/ElasticsearchWriter/SSHRunTest.php
@@ -5,42 +5,13 @@
  */
 namespace Keboola\ElasticsearchWriter;
 
-use Elasticsearch;
-use Keboola\ElasticsearchWriter\Exception\UserException;
 use Symfony\Component\Yaml\Yaml;
 
 class SSHRunTest extends AbstractTest
 {
-	/**
-	 * @var Writer
-	 */
-	protected $writer;
-
-	protected $index = 'keboola_es_writer_run_test';
-
-	protected function setUp()
-	{
-		$this->writer = new Writer(sprintf('%s:%s', getenv('EX_ES_HOST'), getenv('EX_ES_HOST_PORT')));
-
-		$this->cleanUp();
-	}
-
-	/**
-	 * Cleanup test workspace
-	 *
-	 * @throws Elasticsearch\Common\Exceptions\Missing404Exception
-	 * @throws \Exception
-	 */
 	protected function cleanUp()
 	{
-		$params = ['index' => $this->index];
-
-		if ($this->writer->getClient()->indices()->exists($params)) {
-			$response = $this->writer->getClient()->indices()->delete($params);
-
-			$this->assertArrayHasKey('acknowledged', $response);
-			$this->assertTrue($response['acknowledged']);
-		}
+		parent::cleanUp();
 
 		$configPath = './tests/data/run/config.yml';
 		if (file_exists($configPath)) {

--- a/tests/Keboola/ElasticsearchWriter/TypesMappingTest.php
+++ b/tests/Keboola/ElasticsearchWriter/TypesMappingTest.php
@@ -1,0 +1,218 @@
+<?php
+
+namespace Keboola\ElasticsearchWriter;
+
+use Symfony\Component\Yaml\Yaml;
+
+class TypesMappingTest extends AbstractTest
+{
+	/** @var bool */
+	private $textSupportedBySrv;
+
+	protected function setUp()
+	{
+		parent::setUp();
+
+		// https://www.elastic.co/blog/strings-are-dead-long-live-strings
+		$version = $this->writer->getClient()->info()['version']['number'];
+		$this->textSupportedBySrv = version_compare($version, '5.0', '>=');
+	}
+
+	public function testRunActionWithColumnsMapping()
+	{
+		$stringType = $this->textSupportedBySrv ? 'text' : 'string';
+		$config = [
+			"parameters" => [
+				"elastic" => [
+					"host" => getenv('EX_ES_HOST'),
+					"port" => getenv('EX_ES_HOST_PORT'),
+				],
+				"tables" => [
+					[
+						"file" => "types.csv",
+						"index" => $this->index,
+						"type" => "types",
+						"id" => "long-db",
+						"export" => true,
+						"items" => [
+							[
+								"name" => "long",
+								"dbName" => "long-db",
+								"type" => "long",
+								"nullable" => false,
+							],
+							[
+								"name" => "int-nullable",
+								"dbName" => "int-nullable",
+								"type" => "integer",
+								"nullable" => true,
+							],
+							[
+								"name" => "double",
+								"dbName" => "double-db",
+								"type" => "double",
+								"nullable" => false,
+							],
+							[
+								"name" => "float-nullable",
+								"dbName" => "float-nullable",
+								"type" => "float",
+								"nullable" => true,
+							],
+							[
+								"name" => "bool",
+								"dbName" => "bool-db",
+								"type" => "boolean",
+								"nullable" => false,
+							],
+							[
+								"name" => "bool-nullable",
+								"dbName" => "bool-nullable",
+								"type" => "boolean",
+								"nullable" => true,
+							],
+							[
+								"name" => "ignored",
+								"dbName" => "ignored",
+								"type" => "ignore",
+								"nullable" => false,
+							],
+							[
+								"name" => "string",
+								"dbName" => "string-db",
+								"type" => $stringType,
+								"nullable" => false,
+							],
+							[
+								"name" => "string-nullable",
+								"dbName" => "string-nullable",
+								"type" => $stringType,
+								"nullable" => true,
+							],
+							[
+								"name" => "text-nullable",
+								"dbName" => "text-nullable",
+								"type" => $stringType,
+								"nullable" => true,
+							]
+						],
+					]
+				]
+			]
+		];
+
+		$yaml = Yaml::dump($config);
+
+		$inTablesDir = './tests/data/run/in/tables';
+		if (!is_dir($inTablesDir)) {
+			mkdir($inTablesDir, 0777, true);
+		}
+
+		file_put_contents('./tests/data/run/config.yml', $yaml);
+
+		copy('./tests/data/csv/types.csv', $inTablesDir . '/types.csv');
+
+		$lastOutput = exec('php ./src/run.php --data=./tests/data/run', $output, $returnCode);
+		$this->assertEquals(0, $returnCode);
+		$this->assertRegExp('/Elasticsearch writer finished successfully/ui', $lastOutput);
+
+		// One batch
+		$this->assertEquals(1, $this->parseBatchCountFromOutput($output));
+
+		// Wait for update
+		sleep(2);
+
+		// Check mapping
+		$indices = $this->writer->getClient()->indices()->getMapping(["index" => $this->index]);
+		// Response differs between versions,
+		// https://www.elastic.co/guide/en/elasticsearch/reference/current/removal-of-types.html
+		$mapping =
+			$indices[$this->index]['mappings']['types']['properties'] ??
+			$indices[$this->index]['mappings']['properties'];
+		$mapping = array_map(function (array $item) {
+			unset($item['fields']);
+			return $item;
+		}, $mapping);
+		$this->assertSame(
+			[
+				'bool-db' => ['type' => 'boolean'],
+				'bool-nullable' => ['type' => 'boolean'],
+				'double-db' => ['type' => 'double'],
+				'float-nullable' => ['type' => 'float'],
+				'int-nullable' => ['type' => 'integer'],
+				'long-db' => ['type' => 'long'],
+				'missing-in-config' => ['type' => $stringType],
+				'string-db' => ['type' => $stringType],
+				'string-nullable' => ['type' => $stringType],
+				'text-nullable' => ['type' => $stringType],
+			],
+			$mapping
+		);
+
+		// Check values
+		$response = $this->writer->getClient()->search(['_source' => true]);
+		$hits = $response['hits']['hits'];
+		usort($hits, function (array $a, array $b) {
+			return $a['_id'] - $b['_id'];
+		});
+		$this->assertSame([
+			[
+				'_index' => 'keboola_es_writer_test',
+				'_type' => 'types',
+				'_id' => '1',
+				'_score' => 1.0,
+				'_source' =>
+					[
+						'long-db' => 1,
+						'int-nullable' => 2,
+						'double-db' => 1.0,
+						'float-nullable' => 20.0,
+						'bool-db' => true,
+						'bool-nullable' => false,
+						'string-db' => 'def',
+						'string-nullable' => 'xyz',
+						'text-nullable' => 'xyz',
+						'missing-in-config' => 'xyz',
+					],
+			],
+			[
+				'_index' => 'keboola_es_writer_test',
+				'_type' => 'types',
+				'_id' => '2',
+				'_score' => 1.0,
+				'_source' =>
+					[
+						'long-db' => 2,
+						'int-nullable' => null,
+						'double-db' => 0.0,
+						'float-nullable' => null,
+						'bool-db' => false,
+						'bool-nullable' => null,
+						'string-db' => '',
+						'string-nullable' => null,
+						'text-nullable' => null,
+						'missing-in-config' => '',
+					],
+			],
+			[
+				'_index' => 'keboola_es_writer_test',
+				'_type' => 'types',
+				'_id' => '3',
+				'_score' => 1.0,
+				'_source' =>
+					[
+						'long-db' => 3,
+						'int-nullable' => 4,
+						'double-db' => 100.0,
+						'float-nullable' => 200.0,
+						'bool-db' => true,
+						'bool-nullable' => false,
+						'string-db' => 'def2',
+						'string-nullable' => 'xyz3',
+						'text-nullable' => 'xyz3',
+						'missing-in-config' => 'xyz3',
+					],
+			],
+		], $hits);
+	}
+}

--- a/tests/data/csv/types.csv
+++ b/tests/data/csv/types.csv
@@ -1,0 +1,4 @@
+"long","int-nullable","double","float-nullable","ignored","bool","bool-nullable","string","string-nullable","text-nullable","missing-in-config"
+"1","2","1.0","20.0","abc","1","0","def","xyz","xyz","xyz"
+"2","","","","","","","","","",""
+"3","4","100.0","200.0","abc1","true","false","def2","xyz3","xyz3","xyz3"


### PR DESCRIPTION
Solving: https://keboola.atlassian.net/browse/COM-264

Changes: 
- If columns mapping is present and index not exists, ... then is created a new index with mapping from configuration.
- Fields in API requests to ElasticSearch have correct PHP types (int, float, bool, string), according to the mapping in configuration. 
- Empty string from CSV is converted to null if column is nullable.