### PR TITLE
Add option to delete index before load

### DIFF
--- a/src/Keboola/ElasticsearchWriter/Application.php
+++ b/src/Keboola/ElasticsearchWriter/Application.php
@@ -163,6 +163,9 @@ class Application
 
 
 			try {
+				if (isset($table['deleteIndexBeforeLoad']) && $table['deleteIndexBeforeLoad'] === true) {
+					$this->writer->deleteIndexIfExists($options->getIndex());
+				}
 				$this->writer->loadFile($file, $options, $idColumn);
 			} catch (UserException $e) {
 				// Add prefix to message

--- a/src/Keboola/ElasticsearchWriter/Writer.php
+++ b/src/Keboola/ElasticsearchWriter/Writer.php
@@ -84,6 +84,20 @@ class Writer
 		}
 	}
 
+	public function deleteIndexIfExists($indexName)
+	{
+		$indexExists = $this->client->indices()->exists(['index' => $indexName]);
+		if (!$indexExists) {
+			return;
+		}
+
+		$this->client->indices()->delete(['index' => $indexName]);
+		$this->logger->info(sprintf(
+			'Index "%s" has been deleted',
+			$indexName
+		));
+	}
+
 	private function mapRowsToRequestBody(LoadOptions $options, array $csvHeader, $primaryIndex, Iterator $rows): Generator
 	{
 		foreach ($rows as $line => $values) {


### PR DESCRIPTION
Changes:

- Add option to delete index before load using `deleteIndexBeforeLoad` on table level

---

Probably won't be needed. During implementation I realised there is "primary key" support.